### PR TITLE
Add CNAME for custom domain mknop.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mknop.dev


### PR DESCRIPTION
## Purpose

Adding `CNAME` file with my custom domain. This will be used to route to `maknop.github.io`.